### PR TITLE
Add a destroy method for FlowChart to support rerendering

### DIFF
--- a/src/FlowChart.ts
+++ b/src/FlowChart.ts
@@ -27,6 +27,10 @@ export class FlowChart {
     return el
   }
 
+  destroy() {
+    this.elements.forEach((element) => { element.unregister() })
+  }
+
   render(element: HTMLElement) {
     const svg = select(element)
       .append('svg')

--- a/src/FlowElement.ts
+++ b/src/FlowElement.ts
@@ -37,6 +37,10 @@ export class FlowElement {
     return destinationElement
   }
 
+  unregister() {
+    delete flowElementsById[this.id]
+  }
+
   private register() {
     if (flowElementsById[this.id]) {
       throw new Error('ID ' + this.id + 'is already registered!')


### PR DESCRIPTION
While trying to recreate FlowCharts, the FlowElement table was not
being cleared.  By calling destroy on your FlowChart, you can create a
new one without any id conflicts.

Addresses issue: #3 
